### PR TITLE
updating http-server dependency to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "divhide": "2.0.1",
-    "http-server": "0.8.5",
+    "http-server": "0.9.0",
     "lodash": "4.2.X",
     "opener": "1.4.1",
     "showdown": "^1.3.0"


### PR DESCRIPTION
https://github.com/indexzero/http-server/issues/244
It solved the issue of server crashing with : "header content contains invalid characters'); ^ TypeError: The header content contains invalid characters"